### PR TITLE
VME-665 - Image Processor - convert image URL to needed format

### DIFF
--- a/VirtoCommerce.LiquidThemeEngine/Filters/UrlFilters.cs
+++ b/VirtoCommerce.LiquidThemeEngine/Filters/UrlFilters.cs
@@ -218,7 +218,7 @@ namespace VirtoCommerce.LiquidThemeEngine.Filters
         /// <param name="width">new width (optional)</param>
         /// <param name="height">new height (optional)</param>
         /// <returns></returns>
-        public static string ImageUrl(TemplateContext context, string inputUrl, int width = 0, int height = 0)
+        public static string ImageUrl(TemplateContext context, string inputUrl, int? width = null, int? height = null)
         {
             var themeEngine = (ShopifyLiquidThemeEngine)context.TemplateLoader;
             return themeEngine.UrlBuilder.ToImageAbsolute(inputUrl, width, height);

--- a/VirtoCommerce.LiquidThemeEngine/Filters/UrlFilters.cs
+++ b/VirtoCommerce.LiquidThemeEngine/Filters/UrlFilters.cs
@@ -207,7 +207,21 @@ namespace VirtoCommerce.LiquidThemeEngine.Filters
 
         public static string TermsToString(TemplateContext context, IList<Term> terms)
         {
-            return string.Join(";", terms.ToStrings() ?? new List<string> { });          
+            return string.Join(";", terms.ToStrings() ?? new List<string> { });
+        }
+
+        /// <summary>
+        /// Generate corrected with Image Processor URL to image (with optional transform width and height)
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="inputUrl">raw image URL</param>
+        /// <param name="width">new width (optional)</param>
+        /// <param name="height">new height (optional)</param>
+        /// <returns></returns>
+        public static string ImageUrl(TemplateContext context, string inputUrl, int width = 0, int height = 0)
+        {
+            var themeEngine = (ShopifyLiquidThemeEngine)context.TemplateLoader;
+            return themeEngine.UrlBuilder.ToImageAbsolute(inputUrl, width, height);
         }
 
         /// <summary>
@@ -247,7 +261,7 @@ namespace VirtoCommerce.LiquidThemeEngine.Filters
         /// <param name="context"></param>
         /// <param name="keyword">search keyword</param>
         /// <returns>example: /collection?q=foo</returns>
-        public static string AddSearchByKeywordUrl (TemplateContext context, string keyword)
+        public static string AddSearchByKeywordUrl(TemplateContext context, string keyword)
         {
             return BuildUriWithSearchQueryString(context, criteria =>
             {

--- a/VirtoCommerce.Storefront.Model/Common/IStorefrontUrlBuilder.cs
+++ b/VirtoCommerce.Storefront.Model/Common/IStorefrontUrlBuilder.cs
@@ -10,5 +10,6 @@ namespace VirtoCommerce.Storefront.Model.Common
         string ToAppRelative(string virtualPath);
         string ToAppRelative(string virtualPath, Store store, Language language);
         string ToLocalPath(string virtualPath);
+        string ToImageAbsolute(string virtualPath, int width, int height);
     }
 }

--- a/VirtoCommerce.Storefront.Model/Common/IStorefrontUrlBuilder.cs
+++ b/VirtoCommerce.Storefront.Model/Common/IStorefrontUrlBuilder.cs
@@ -10,6 +10,6 @@ namespace VirtoCommerce.Storefront.Model.Common
         string ToAppRelative(string virtualPath);
         string ToAppRelative(string virtualPath, Store store, Language language);
         string ToLocalPath(string virtualPath);
-        string ToImageAbsolute(string virtualPath, int width, int height);
+        string ToImageAbsolute(string virtualPath, int? width, int? height);
     }
 }

--- a/VirtoCommerce.Storefront.Model/StaticContent/IImageProcessor.cs
+++ b/VirtoCommerce.Storefront.Model/StaticContent/IImageProcessor.cs
@@ -2,6 +2,6 @@ namespace VirtoCommerce.Storefront.Model.StaticContent
 {
     public interface IImageProcessor
     {
-        string ResolveUrl(string inputUrl, int width, int height);
+        string ResolveUrl(string inputUrl, int? width, int? height);
     }
 }

--- a/VirtoCommerce.Storefront.Model/StaticContent/IImageProcessor.cs
+++ b/VirtoCommerce.Storefront.Model/StaticContent/IImageProcessor.cs
@@ -1,0 +1,7 @@
+namespace VirtoCommerce.Storefront.Model.StaticContent
+{
+    public interface IImageProcessor
+    {
+        string ResolveUrl(string inputUrl, int width, int height);
+    }
+}

--- a/VirtoCommerce.Storefront/Domain/ImageProcessing/DefaultImageProcessor.cs
+++ b/VirtoCommerce.Storefront/Domain/ImageProcessing/DefaultImageProcessor.cs
@@ -1,0 +1,12 @@
+using VirtoCommerce.Storefront.Model.StaticContent;
+
+namespace VirtoCommerce.Storefront.Domain.ImageProcessing
+{
+    public class DefaultImageProcessor : IImageProcessor
+    {
+        public string ResolveUrl(string inputUrl, int width, int height)
+        {
+            return inputUrl;
+        }
+    }
+}

--- a/VirtoCommerce.Storefront/Domain/ImageProcessing/DefaultImageProcessor.cs
+++ b/VirtoCommerce.Storefront/Domain/ImageProcessing/DefaultImageProcessor.cs
@@ -4,7 +4,7 @@ namespace VirtoCommerce.Storefront.Domain.ImageProcessing
 {
     public class DefaultImageProcessor : IImageProcessor
     {
-        public string ResolveUrl(string inputUrl, int width, int height)
+        public string ResolveUrl(string inputUrl, int? width, int? height)
         {
             return inputUrl;
         }

--- a/VirtoCommerce.Storefront/Domain/ImageProcessing/ImageProcessorOptions.cs
+++ b/VirtoCommerce.Storefront/Domain/ImageProcessing/ImageProcessorOptions.cs
@@ -1,0 +1,8 @@
+namespace VirtoCommerce.Storefront.Domain.ImageProcessing
+{
+    public class ImageProcessorOptions
+    {
+        public string Provider { get; set; }
+        public string ServiceUrl { get; set; }
+    }
+}

--- a/VirtoCommerce.Storefront/Domain/ImageProcessing/ImagekitImageProcessor.cs
+++ b/VirtoCommerce.Storefront/Domain/ImageProcessing/ImagekitImageProcessor.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.Storefront.Model.StaticContent;
+
+namespace VirtoCommerce.Storefront.Domain.ImageProcessing
+{
+    public class ImagekitImageProcessor : IImageProcessor
+    {
+        private readonly string _serviceUrl;
+
+        public ImagekitImageProcessor(IOptions<ImageProcessorOptions> options)
+        {
+            _serviceUrl = options.Value.ServiceUrl.TrimEnd('/');
+        }
+        public string ResolveUrl(string inputUrl, int width, int height)
+        {
+            string tmpUrl = inputUrl.TrimStart('/');
+            if (tmpUrl.StartsWith("http"))
+            {
+                tmpUrl = tmpUrl.Replace("http://", "").Replace("https://", "");
+                string[] urlParts = tmpUrl.Split('/');
+                tmpUrl = string.Join("/", urlParts.Skip(1));
+            }
+            string result = string.Join("/", _serviceUrl, tmpUrl);
+            if (width > 0 && height > 0)
+            {
+                result += $"?tr=w-{width},h-{height}";
+            }
+            return result;
+        }
+    }
+}

--- a/VirtoCommerce.Storefront/Domain/ImageProcessing/ImagekitImageProcessor.cs
+++ b/VirtoCommerce.Storefront/Domain/ImageProcessing/ImagekitImageProcessor.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Storefront.Model.StaticContent;
 
@@ -10,10 +11,14 @@ namespace VirtoCommerce.Storefront.Domain.ImageProcessing
 
         public ImagekitImageProcessor(IOptions<ImageProcessorOptions> options)
         {
-            _serviceUrl = options.Value.ServiceUrl.TrimEnd('/');
+            _serviceUrl = options.Value?.ServiceUrl?.TrimEnd('/');
         }
-        public string ResolveUrl(string inputUrl, int width, int height)
+        public string ResolveUrl(string inputUrl, int? width, int? height)
         {
+            if (string.IsNullOrEmpty(inputUrl))
+            {
+                return inputUrl;
+            }
             string tmpUrl = inputUrl.TrimStart('/');
             if (tmpUrl.StartsWith("http"))
             {
@@ -22,9 +27,18 @@ namespace VirtoCommerce.Storefront.Domain.ImageProcessing
                 tmpUrl = string.Join("/", urlParts.Skip(1));
             }
             string result = string.Join("/", _serviceUrl, tmpUrl);
-            if (width > 0 && height > 0)
+            if (width.HasValue || height.HasValue)
             {
-                result += $"?tr=w-{width},h-{height}";
+                StringBuilder imageParam = new StringBuilder("?tr=");
+                if (width.HasValue && width.Value > 0)
+                {
+                    imageParam.Append($"w-{width.Value},");
+                }
+                if (height.HasValue && height.Value > 0)
+                {
+                    imageParam.Append($"h-{height.Value}");
+                }
+                result += imageParam.ToString().TrimEnd(',');
             }
             return result;
         }

--- a/VirtoCommerce.Storefront/Infrastructure/StorefrontUrlBuilder.cs
+++ b/VirtoCommerce.Storefront/Infrastructure/StorefrontUrlBuilder.cs
@@ -129,7 +129,7 @@ namespace VirtoCommerce.Storefront.Infrastructure
             return _hostEnv.MapPath(virtualPath);
         }
 
-        public string ToImageAbsolute(string virtualPath, int width, int height)
+        public string ToImageAbsolute(string virtualPath, int? width, int? height)
         {
             return _imageProcessor.ResolveUrl(virtualPath, width, height);
         }

--- a/VirtoCommerce.Storefront/Infrastructure/StorefrontUrlBuilder.cs
+++ b/VirtoCommerce.Storefront/Infrastructure/StorefrontUrlBuilder.cs
@@ -7,6 +7,7 @@ using VirtoCommerce.Storefront.Domain;
 using VirtoCommerce.Storefront.Extensions;
 using VirtoCommerce.Storefront.Model;
 using VirtoCommerce.Storefront.Model.Common;
+using VirtoCommerce.Storefront.Model.StaticContent;
 using VirtoCommerce.Storefront.Model.Stores;
 using VirtoCommerce.Tools;
 
@@ -21,16 +22,19 @@ namespace VirtoCommerce.Storefront.Infrastructure
         private readonly IWorkContextAccessor _workContextAccessor;
         private readonly IHostingEnvironment _hostEnv;
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IImageProcessor _imageProcessor;
 
         private static readonly string[] UrlContainingQueryParameters = { "ReturnUrl", };
 
-        public StorefrontUrlBuilder(IUrlBuilder urlBuilder, IWorkContextAccessor workContextAccessor, IHostingEnvironment hostEnv, IHttpContextAccessor httpContextAccessor)
+        public StorefrontUrlBuilder(IUrlBuilder urlBuilder, IWorkContextAccessor workContextAccessor, IHostingEnvironment hostEnv,
+            IHttpContextAccessor httpContextAccessor, IImageProcessor imageProcessor)
         {
             _urlBuilder = urlBuilder;
             _workContextAccessor = workContextAccessor;
             //_urlBuilderContext = workContext.ToToolsContext();
             _hostEnv = hostEnv;
             _httpContextAccessor = httpContextAccessor;
+            _imageProcessor = imageProcessor;
         }
 
         #region IStorefrontUrlBuilder members
@@ -124,6 +128,12 @@ namespace VirtoCommerce.Storefront.Infrastructure
         {
             return _hostEnv.MapPath(virtualPath);
         }
+
+        public string ToImageAbsolute(string virtualPath, int width, int height)
+        {
+            return _imageProcessor.ResolveUrl(virtualPath, width, height);
+        }
+
         #endregion
     }
 }

--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -380,10 +380,7 @@ namespace VirtoCommerce.Storefront
             if (imageProcessorOptions.Provider.EqualsInvariant("Imagekit"))
             {
                 services.AddSingleton<IImageProcessor, ImagekitImageProcessor>();
-                services.Configure<ImageProcessorOptions>(options =>
-                {
-                    options.ServiceUrl = imageProcessorOptions.ServiceUrl;
-                });
+                services.Configure<ImageProcessorOptions>(Configuration.GetSection("VirtoCommerce:ImageProcessor"));
             }
             else
             {

--- a/VirtoCommerce.Storefront/Startup.cs
+++ b/VirtoCommerce.Storefront/Startup.cs
@@ -31,6 +31,7 @@ using VirtoCommerce.Storefront.Caching.Redis;
 using VirtoCommerce.Storefront.DependencyInjection;
 using VirtoCommerce.Storefront.Domain;
 using VirtoCommerce.Storefront.Domain.Cart;
+using VirtoCommerce.Storefront.Domain.ImageProcessing;
 using VirtoCommerce.Storefront.Domain.Security;
 using VirtoCommerce.Storefront.Extensions;
 using VirtoCommerce.Storefront.Filters;
@@ -372,6 +373,22 @@ namespace VirtoCommerce.Storefront
             });
 
             services.AddResponseCompression();
+
+            // Image Processor - correct image URL with image processing service endpoint
+            var imageProcessorOptions = new ImageProcessorOptions();
+            Configuration.GetSection("VirtoCommerce:ImageProcessor").Bind(imageProcessorOptions);
+            if (imageProcessorOptions.Provider.EqualsInvariant("Imagekit"))
+            {
+                services.AddSingleton<IImageProcessor, ImagekitImageProcessor>();
+                services.Configure<ImageProcessorOptions>(options =>
+                {
+                    options.ServiceUrl = imageProcessorOptions.ServiceUrl;
+                });
+            }
+            else
+            {
+                services.AddSingleton<IImageProcessor, DefaultImageProcessor>();
+            }
 
         }
 

--- a/VirtoCommerce.Storefront/appsettings.json
+++ b/VirtoCommerce.Storefront/appsettings.json
@@ -57,7 +57,13 @@
     // This option sets how notification is delivered in reset password workflow. Possible values: "Email", "Phone".
     "ResetPasswordNotificationGateway": "Email",
     // This option sets how notification is delivered in two factor authentication workflow. Possible values: "Email", "Phone".
-    "TwoFactorAuthenticationNotificationGateway": "Phone"
+    "TwoFactorAuthenticationNotificationGateway": "Phone",
+    "ImageProcessor": {
+      // Image Processor Provider, available: "Default", "Imagekit"
+      "Provider": "Default",
+      // Image Processor service URL, replace with your value
+      "ServiceUrl": "Replace with your value"
+    }
   },
   "CookieAuthenticationOptions": {
     "Cookie": {


### PR DESCRIPTION
Currently, two ImageProcessor are implemented (provider is configuring in AppSettings):
"Default" - does not do any conversion with URL
"Imagekit" - replaces image endpoint with the one specified in ServiceUrl in AppSettings. If image has relative path - that adds ServiceUrl as endpoint